### PR TITLE
Migrate to ReactiveSwift 1.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - ReactiveLocation (2.0.0):
-    - ReactiveSwift (= 1.0.0-alpha.1)
-  - ReactiveSwift (1.0.0-alpha.1):
-    - Result (~> 3.0)
-  - Result (3.0.0)
+  - ReactiveLocation (2.0.1):
+    - ReactiveSwift (~> 1.0)
+  - ReactiveSwift (1.0.0):
+    - Result (~> 3.1)
+  - Result (3.1.0)
 
 DEPENDENCIES:
   - ReactiveLocation (from `../`)
@@ -13,10 +13,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ReactiveLocation: 90e299c247c86d22c3dad3553e48f68541e02a1b
-  ReactiveSwift: cf34523b2b0dd8fbfc8fda484b0d0585e3d74955
-  Result: 1b3e431f37cbcd3ad89c6aa9ab0ae55515fae3b6
+  ReactiveLocation: e1b1b3d078bf761fbaa5fa0fdbf78ddd04dc0937
+  ReactiveSwift: f391724ee318a2cfd3e37dfb041cd49ecf4e7869
+  Result: 4e3ed5995ed94d0cd6a09be9a431fce3f3624bbf
 
 PODFILE CHECKSUM: ac296a9d462dde38eb807effdd275857d50aef06
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0.beta.1

--- a/ReactiveLocation.podspec
+++ b/ReactiveLocation.podspec
@@ -38,5 +38,5 @@ DESC
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'ReactiveSwift', '~> 1.0.0-alpha.3'
+  s.dependency 'ReactiveSwift', '~> 1.0'
 end

--- a/ReactiveLocation/Classes/ReactiveLocation.swift
+++ b/ReactiveLocation/Classes/ReactiveLocation.swift
@@ -191,7 +191,7 @@ public class ReactiveLocation: ReactiveLocationService {
             .promoteErrors(LocationAuthorizationError.self)
             .flatMap(.latest) { status -> SignalProducer<LocationAuthorizationLevel, LocationAuthorizationError> in
                 if case .notDetermined = status {
-                    return SignalProducer(signal: cl.delegateObject!.didChangeAuthorizationStatus)
+                    return SignalProducer(cl.delegateObject!.didChangeAuthorizationStatus)
                         .on(started: {
                             switch targetLevel {
                             case .always: cl.requestAlwaysAuthorization()
@@ -213,7 +213,7 @@ public class ReactiveLocation: ReactiveLocationService {
     // MARK: Internal
 
     static private func errorSignal<T>(_ delegateObject: ReactiveLocationManagerDelegate) -> SignalProducer<T, LocationError> {
-        return SignalProducer(signal: delegateObject.didFail)
+        return SignalProducer(delegateObject.didFail)
             .map { $0 as NSError }
             .flatMap (.latest) { (error: NSError) -> SignalProducer<T,LocationError> in
                 return SignalProducer<T,LocationError>(error: LocationError.locationError(CLError(_nsError: error).code))
@@ -221,15 +221,15 @@ public class ReactiveLocation: ReactiveLocationService {
     }
 
     static private func locationSignal(_ delegateObject: ReactiveLocationManagerDelegate) -> SignalProducer<CLLocation, LocationError> {
-        return SignalProducer(signal: delegateObject.didUpdateLocations).promoteErrors(LocationError.self).map { $0.last! }
+        return SignalProducer(delegateObject.didUpdateLocations).promoteErrors(LocationError.self).map { $0.last! }
     }
 
     static private func headingSignal(_ delegateObject: ReactiveLocationManagerDelegate) -> SignalProducer<CLHeading, LocationError> {
-        return SignalProducer(signal: delegateObject.didUpdateHeading).promoteErrors(LocationError.self)
+        return SignalProducer(delegateObject.didUpdateHeading).promoteErrors(LocationError.self)
     }
 
     static private func visitSignal(_ delegateObject: ReactiveLocationManagerDelegate) -> SignalProducer<CLVisit, LocationError> {
-        return SignalProducer(signal: delegateObject.didVisit).promoteErrors(LocationError.self)
+        return SignalProducer(delegateObject.didVisit).promoteErrors(LocationError.self)
     }
 
     static private func regionSignal(_ delegateObject: ReactiveLocationManagerDelegate, regionState: RegionEvent) -> SignalProducer<RegionEvent, LocationError> {
@@ -237,9 +237,9 @@ public class ReactiveLocation: ReactiveLocationService {
         let signal: SignalProducer<RegionEvent, NoError>
         switch regionState {
         case .enter:
-            signal = SignalProducer(signal: delegateObject.didEnterRegion).map { .enter($0) }
+            signal = SignalProducer(delegateObject.didEnterRegion).map { .enter($0) }
         case .exit:
-            signal = SignalProducer(signal: delegateObject.didExitRegion).map { .exit($0) }
+            signal = SignalProducer(delegateObject.didExitRegion).map { .exit($0) }
         }
 
         return signal.promoteErrors(LocationError.self)
@@ -255,7 +255,7 @@ public class ReactiveLocation: ReactiveLocationService {
     }
 
     static private func merge<T, E>(_ signals: [SignalProducer<T, E>]) -> SignalProducer<T, E> {
-        let producers = SignalProducer<SignalProducer<T, E>, E>(values: signals)
+        let producers = SignalProducer<SignalProducer<T, E>, E>(signals)
         return producers.flatten(.merge)
     }
 }


### PR DESCRIPTION
Simple migration from pre-release ReactiveSwift to release version.