### PR TITLE
Fix permission requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## master
 
+- move location permission request out of _ReactiveLocation_ (#22, kudos to @olejnjak)
+
 ## 4.0 beta 1
 
 - completely new version (#19, kudos to @olejnjak)

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "ReactiveCocoa/ReactiveCocoa" "9.0.0"
-github "ReactiveCocoa/ReactiveSwift" "5.0.0"
+github "ReactiveCocoa/ReactiveSwift" "5.0.1"
 github "antitypical/Result" "4.1.0"

--- a/ReactiveLocation/ReactiveLocation.swift
+++ b/ReactiveLocation/ReactiveLocation.swift
@@ -18,13 +18,14 @@ public protocol ReactiveLocationService {
 
 public final class ReactiveLocation: NSObject, ReactiveLocationService, CLLocationManagerDelegate {
     public static let shared = ReactiveLocation()
+    public typealias RequestPermissionCallback = (CLLocationManager) -> ()
     
     public var locationManager: CLLocationManager { return _locationManager }
     public var isVerbose = false
-    public var requestPermission: (CLLocationManager) -> () = { _ in }
     
     private let _locationManager: BetterLocationManager
     private let observerLock = NSLock()
+    private let requestPermission: RequestPermissionCallback
     
     private var observerCount = 0 {
         didSet {
@@ -60,8 +61,9 @@ public final class ReactiveLocation: NSObject, ReactiveLocationService, CLLocati
     
     // MARK: - Initializers
     
-    public override init() {
+    public init(requestPermission rp: @escaping RequestPermissionCallback) {
         _locationManager = BetterLocationManager()
+        requestPermission = rp
         super.init()
         locationManager.delegate = self
     }

--- a/ReactiveLocation/ReactiveLocation.swift
+++ b/ReactiveLocation/ReactiveLocation.swift
@@ -21,6 +21,7 @@ public final class ReactiveLocation: NSObject, ReactiveLocationService, CLLocati
     
     public var locationManager: CLLocationManager { return _locationManager }
     public var isVerbose = false
+    public var requestPermission: (CLLocationManager) -> () = { _ in }
     
     private let _locationManager: BetterLocationManager
     private let observerLock = NSLock()
@@ -98,15 +99,7 @@ public final class ReactiveLocation: NSObject, ReactiveLocationService, CLLocati
                 return
             }
             
-            if Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription") != nil {
-                locationManager.requestAlwaysAuthorization()
-            } else if Bundle.main.object(forInfoDictionaryKey: "NSLocationUsageDescription") != nil {
-                locationManager.requestAlwaysAuthorization()
-            } else if Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysUsageDescription") != nil {
-                locationManager.requestAlwaysAuthorization()
-            } else if Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil {
-                locationManager.requestWhenInUseAuthorization()
-            }
+            self?.requestPermission(locationManager)
             observer.send(value: ())
             observer.sendCompleted()
         }

--- a/ReactiveLocation/ReactiveLocation.swift
+++ b/ReactiveLocation/ReactiveLocation.swift
@@ -17,7 +17,6 @@ public protocol ReactiveLocationService {
 }
 
 public final class ReactiveLocation: NSObject, ReactiveLocationService, CLLocationManagerDelegate {
-    public static let shared = ReactiveLocation()
     public typealias RequestPermissionCallback = (CLLocationManager) -> ()
     
     public var locationManager: CLLocationManager { return _locationManager }

--- a/ReactiveLocationExample/AppDelegate.swift
+++ b/ReactiveLocationExample/AppDelegate.swift
@@ -9,12 +9,14 @@
 import UIKit
 import ReactiveLocation
 
+let reactiveLocation = ReactiveLocation { $0.requestWhenInUseAuthorization() } // but do your DI properly ☝️
+
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        ReactiveLocation.shared.isVerbose = true
+        reactiveLocation.isVerbose = true
         return true
     }
 }

--- a/ReactiveLocationExample/LocationViewController.swift
+++ b/ReactiveLocationExample/LocationViewController.swift
@@ -26,7 +26,7 @@ final class LocationViewController: UIViewController {
     // MARK: - Private helpers
     
     private func setupBindings() {
-        let coordinate = ReactiveLocation.shared.locationProducer()
+        let coordinate = reactiveLocation.locationProducer()
             .map { $0.coordinate }
         
         locationLabel.reactive.text <~ coordinate.map { String($0.latitude) + "," + String($0.longitude) }


### PR DESCRIPTION
This PR addresses #21 issue. ReactiveLocation no longer forces its users to require access to always location permission.

#### Checklist
- [x] Updated CHANGELOG.md.