### PR TITLE
Add producer for single location with timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## master
 
 - move location permission request out of _ReactiveLocation_ (#22, kudos to @olejnjak)
+- add single location producer that returns `nil` if timeout occurs (#23, kudos to @olejnjak)
 
 ## 4.0 beta 1
 

--- a/ReactiveLocationExample/AppDelegate.swift
+++ b/ReactiveLocationExample/AppDelegate.swift
@@ -9,14 +9,17 @@
 import UIKit
 import ReactiveLocation
 
-let reactiveLocation = ReactiveLocation { $0.requestWhenInUseAuthorization() } // but do your DI properly ☝️
+let reactiveLocation: ReactiveLocationService = { // but do your DI properly ☝️
+    let rl = ReactiveLocation { $0.requestWhenInUseAuthorization() }
+    rl.isVerbose = true
+    return rl
+}()
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        reactiveLocation.isVerbose = true
         return true
     }
 }


### PR DESCRIPTION
Adds `singleLocationProducer(timeout:)` which returns optional location as it is a frequent case in our apps (#20).

The producer returns first location received or nil if timeout occurs.

#### Checklist
- [x] Updated CHANGELOG.md.